### PR TITLE
Make items go into the lowest tiered available slot they can in the component UI

### DIFF
--- a/Minecraft/src/main/java/li/cil/ocreloaded/minecraft/common/menu/ComponentQuickMove.java
+++ b/Minecraft/src/main/java/li/cil/ocreloaded/minecraft/common/menu/ComponentQuickMove.java
@@ -9,7 +9,6 @@ import net.minecraft.world.item.ItemStack;
 public class ComponentQuickMove {
     
     public static ItemStack quickMoveStack(List<Slot> slots, Player player, int index) {
-        // TODO: Prefer exact tier match - can make isBetterMatch method
         Slot slot = slots.get(index);
         if (slot == null || !slot.hasItem()) {
             return ItemStack.EMPTY;
@@ -54,12 +53,20 @@ public class ComponentQuickMove {
         int target = -1;
         for (int i = 0; i < slots.size(); i++) {
             Slot slot = slots.get(i);
-            if ((slot instanceof ComponentSlot) != isComponentSlot) continue;
+            // Must be type specified in passed flag
+            if (slot instanceof ComponentSlot != isComponentSlot) continue;
+
+            // Must pass the slot's checks
             if (!slot.mayPlace(sourceStack)) continue;
+
+            // If occupied, must be the same item
             if (slot.hasItem() && !ItemStack.isSameItem(slot.getItem(), sourceStack)) continue;
+
+            // If occupied, must fit the slot's stack size
             if (slot.hasItem() && slot.getItem().getCount() >= slot.getMaxStackSize()) continue;
-            if (!slot.hasItem() && target != -1) continue;
-            if (slot.hasItem()) return i;
+
+            // If and a target is already found, and target is a component slot, then must be of a lower tier than the chosen target
+            if (isComponentSlot && target != -1 && ((ComponentSlot) slot).getTier() >= ((ComponentSlot) slots.get(target)).getTier()) continue;
             target = i;
         }
 

--- a/Minecraft/src/main/java/li/cil/ocreloaded/minecraft/common/menu/ComponentQuickMove.java
+++ b/Minecraft/src/main/java/li/cil/ocreloaded/minecraft/common/menu/ComponentQuickMove.java
@@ -66,7 +66,11 @@ public class ComponentQuickMove {
             if (slot.hasItem() && slot.getItem().getCount() >= slot.getMaxStackSize()) continue;
 
             // If and a target is already found, and target is a component slot, then must be of a lower tier than the chosen target
-            if (isComponentSlot && target != -1 && ((ComponentSlot) slot).getTier() >= ((ComponentSlot) slots.get(target)).getTier()) continue;
+            if (
+                isComponentSlot
+                && target != -1 
+                && ((ComponentSlot) slot).getTier() >= ((ComponentSlot) slots.get(target)).getTier()
+            ) continue;
             target = i;
         }
 

--- a/Minecraft/src/main/java/li/cil/ocreloaded/minecraft/common/menu/ComponentQuickMove.java
+++ b/Minecraft/src/main/java/li/cil/ocreloaded/minecraft/common/menu/ComponentQuickMove.java
@@ -53,6 +53,7 @@ public class ComponentQuickMove {
         int target = -1;
         for (int i = 0; i < slots.size(); i++) {
             Slot slot = slots.get(i);
+            
             // Must be type specified in passed flag
             if (slot instanceof ComponentSlot != isComponentSlot) continue;
 
@@ -71,6 +72,7 @@ public class ComponentQuickMove {
                 && target != -1 
                 && ((ComponentSlot) slot).getTier() >= ((ComponentSlot) slots.get(target)).getTier()
             ) continue;
+
             target = i;
         }
 


### PR DESCRIPTION
The logic is that a slot with a lower tier is preferred, so the first slot found with the lowest tier is the one selected for quick moving.