### PR TITLE
Resolve the build errors caused by dependsOn.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ projects/*/bin
 .vscode
 .idea
 .eclipse
+buildSrc/.kotlin

--- a/buildSrc/src/main/kotlin/oc-loader.gradle.kts
+++ b/buildSrc/src/main/kotlin/oc-loader.gradle.kts
@@ -44,3 +44,7 @@ tasks.withType<ShadowJar> {
     relocate("com.typesafe.config", "li.cil.ocreloaded.lib.config")
     archiveClassifier.set("all")
 }
+
+tasks.named("processResources") {
+    dependsOn(project(":Minecraft").tasks.named("processResources"))
+}

--- a/projects/Core/build.gradle.kts
+++ b/projects/Core/build.gradle.kts
@@ -6,9 +6,41 @@ repositories {
     mavenCentral()
 }
 
+sourceSets {
+    val jninject by creating {}
+}
+
+val moddedJNLua by tasks.registering(Jar::class) {
+    archiveFileName.set("OpenComputers-JNLua-injected.jar")
+    destinationDirectory.set(layout.buildDirectory.dir("injected-libs"))
+
+    from(zipTree(file("../../libs/OpenComputers-JNLua.jar"))) {
+        exclude("META-INF/MANIFEST.MF")
+    }
+    from(sourceSets["jninject"].output)
+
+    manifest {
+        attributes("Automatic-Module-Name" to "li.cil.oc.jnlua")
+    }
+}
+
+val moddedLuaJ by tasks.registering(Jar::class) {
+    archiveFileName.set("OpenComputers-LuaJ-modded.jar")
+    destinationDirectory.set(layout.buildDirectory.dir("injected-libs"))
+
+    from(zipTree(file("../../libs/OpenComputers-LuaJ.jar"))) {
+        exclude("META-INF/MANIFEST.MF")
+    }
+
+    manifest {
+        attributes("Automatic-Module-Name" to "li.cil.oc.luaj")
+    }
+}
+
 dependencies {
     compileOnly(libs.slf4j)
 
     shadeApi(libs.typesafeConfig)
-    shadeApi(files("../../libs/OpenComputers-JNLua.jar", "../../libs/OpenComputers-LuaJ.jar"))
+    shadeApi(files(moddedJNLua))
+    shadeApi(files(moddedLuaJ))
 }

--- a/projects/Core/src/jninject/java/li/cil/repack/com/naef/jnlua/CustomLoader.java
+++ b/projects/Core/src/jninject/java/li/cil/repack/com/naef/jnlua/CustomLoader.java
@@ -1,0 +1,9 @@
+package li.cil.repack.com.naef.jnlua;
+
+public class CustomLoader {
+    
+    public static void load(String lib) {
+        System.load(lib);
+    }
+
+}

--- a/projects/Fabric/build.gradle.kts
+++ b/projects/Fabric/build.gradle.kts
@@ -40,7 +40,6 @@ afterEvaluate {
     extensions.getByType<RegExtension>().configureJarTask(tasks.shadowJar.get())
 }
 
-// TODO: Figure out how to declare this in :Minecraft instead
 tasks.named("processResources") {
 	dependsOn(project(":Minecraft").tasks.named("processResources"))
 }

--- a/projects/Fabric/build.gradle.kts
+++ b/projects/Fabric/build.gradle.kts
@@ -27,8 +27,9 @@ sourceSets.main {
 }
 
 tasks.withType<RemapJarTask> {
+    dependsOn(tasks.shadowJar)
     inputFile.set(tasks.shadowJar.get().archiveFile)
-    archiveClassifier.set("")
+    archiveClassifier.set("mod")
 }
 
 tasks.build {

--- a/projects/Fabric/build.gradle.kts
+++ b/projects/Fabric/build.gradle.kts
@@ -1,6 +1,5 @@
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar;
-import net.fabricmc.loom.task.RemapJarTask;
-import com.matyrobbrt.registrationutils.gradle.RegExtension;
+import com.matyrobbrt.registrationutils.gradle.RegExtension
+import net.fabricmc.loom.task.RemapJarTask
 
 evaluationDependsOn(":Minecraft")
 
@@ -38,8 +37,4 @@ tasks.build {
 
 afterEvaluate {
     extensions.getByType<RegExtension>().configureJarTask(tasks.shadowJar.get())
-}
-
-tasks.named("processResources") {
-	dependsOn(project(":Minecraft").tasks.named("processResources"))
 }

--- a/projects/Minecraft/build.gradle.kts
+++ b/projects/Minecraft/build.gradle.kts
@@ -29,10 +29,6 @@ val generateBlockstatesTask = tasks.register<JavaExec>("generateBlockstates") {
 	outputs.dir(project.layout.buildDirectory.dir("generated/resources"))
 }
 
-tasks.named("processResources") {
-	dependsOn(generateBlockstatesTask)
-}
-
 sourceSets.main.get().resources {
 	srcDir(generateBlockstatesTask)
 }

--- a/projects/Minecraft/src/main/java/li/cil/ocreloaded/minecraft/server/machine/lua/LuaCFactory.java
+++ b/projects/Minecraft/src/main/java/li/cil/ocreloaded/minecraft/server/machine/lua/LuaCFactory.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 
 import li.cil.ocreloaded.core.machine.architecture.luac.LuaCStateFactory;
 import li.cil.ocreloaded.minecraft.common.OCReloadedCommon;
+import li.cil.repack.com.naef.jnlua.CustomLoader;
 import li.cil.repack.com.naef.jnlua.LuaState;
 import li.cil.repack.com.naef.jnlua.LuaState.Library;
 import li.cil.repack.com.naef.jnlua.LuaStateFiveThree;
@@ -67,14 +68,14 @@ public class LuaCFactory {
         LoggerFactory.getLogger(getClass()).info("Loading arch {}", architecture);
         switch (architecture) {
             case "lua52":
-                NativeSupport.getInstance().setLoader(() -> System.load(getTempName(architecture)));
+                NativeSupport.getInstance().setLoader(() -> CustomLoader.load(getTempName(architecture)));
                 return loaded(() -> new LuaState(), LIBRARIES_52);
             case "lua53":
                 // Lua53 still needs Lua52 libs
                 if (createFactory("lua52").isEmpty()) return Optional.empty();
                 NativeSupport.getInstance().setLoader(() -> {
-                    System.load(getTempName("lua52"));
-                    System.load(getTempName(architecture));
+                    CustomLoader.load(getTempName("lua52"));
+                    CustomLoader.load(getTempName(architecture));
                 });
                 return loaded(() -> new LuaStateFiveThree(), LIBRARIES_53);
             default:

--- a/projects/Minecraft/src/main/java/li/cil/ocreloaded/minecraft/server/machine/lua/NativeSupportLoader.java
+++ b/projects/Minecraft/src/main/java/li/cil/ocreloaded/minecraft/server/machine/lua/NativeSupportLoader.java
@@ -1,0 +1,9 @@
+package li.cil.ocreloaded.minecraft.server.machine.lua;
+
+import li.cil.repack.com.naef.jnlua.NativeSupport.Loader;
+
+public interface NativeSupportLoader extends Loader {
+    
+    void loadLib(String libPath);
+
+}

--- a/projects/Minecraft/src/main/resources/ocreloaded.mixins.json
+++ b/projects/Minecraft/src/main/resources/ocreloaded.mixins.json
@@ -1,6 +1,6 @@
 {
     "required": true,
-    "package": "oc.cil.ocreloaded.mixin",
+    "package": "li.cil.ocreloaded.mixin",
     "compatibilityLevel": "JAVA_21",
     "minVersion": "0.8",
     "client": [

--- a/projects/NeoForge/build.gradle.kts
+++ b/projects/NeoForge/build.gradle.kts
@@ -44,3 +44,7 @@ sourceSets.main {
 afterEvaluate {
     extensions.getByType<RegExtension>().configureJarTask(tasks.shadowJar.get())
 }
+
+tasks.named("processResources") {
+    dependsOn(project(":Minecraft").tasks.named("processResources"))
+}

--- a/projects/NeoForge/build.gradle.kts
+++ b/projects/NeoForge/build.gradle.kts
@@ -30,6 +30,8 @@ repositories {
 }
 
 dependencies {
+    jarJar(files(project.configurations.getByName("shade")))
+    jarJar(files(project.configurations.getByName("shadeApi")))
     "additionalRuntimeClasspath"(files(project.configurations.getByName("shade")))
     "additionalRuntimeClasspath"(files(project.configurations.getByName("shadeApi")))
     shadeApi(project(":Minecraft"))

--- a/projects/NeoForge/build.gradle.kts
+++ b/projects/NeoForge/build.gradle.kts
@@ -44,7 +44,3 @@ sourceSets.main {
 afterEvaluate {
     extensions.getByType<RegExtension>().configureJarTask(tasks.shadowJar.get())
 }
-
-tasks.named("processResources") {
-    dependsOn(project(":Minecraft").tasks.named("processResources"))
-}


### PR DESCRIPTION
Unfortunately, as it turns out, declaring the depedency on the task from Minecraft is condemnable enough to gradle that we can't actually do it that way. Let's hardwire it so that it at least builds instead.

Changes very little.